### PR TITLE
위키 문서 작성 기능의 구현

### DIFF
--- a/app/controllers/document.go
+++ b/app/controllers/document.go
@@ -1,26 +1,46 @@
 package controllers
 
 import (
+    "log"
+
     "github.com/revel/revel"
     "github.com/GDG-SSU/wigo/app"
     "github.com/GDG-SSU/wigo/app/models"
+    "github.com/asaskevich/govalidator"
 )
 
 type Document struct {
     *revel.Controller
 }
 
-func (c Document) Write() revel.Result {
+/**
+ * DocumentForm - A struct representing POST form payload
+ */
+type DocumentForm struct {
+    Title   string  `valid:"required"`
+    Content string  `valid:"required"`
+}
 
+func parseForm(p *revel.Params) (DocumentForm, error) {
+    doc := &DocumentForm{}
+    p.Bind(&(doc.Title), "title")
+    p.Bind(&(doc.Content), "content")
+
+    _, err := govalidator.ValidateStruct(doc)
+    return *doc, err
+}
+
+func (c Document) Write() revel.Result {
     // When the submit button is clicked
     if c.Request.Method == "POST" {
-        var title string
-        var content string
-        c.Params.Bind(&title, "title")
-        c.Params.Bind(&content, "content")
-
-        // Save to database
-        app.DB.Create(&models.Document{Title: title, Content: content})
+        df, err := parseForm(c.Params)
+        if (err == nil) {
+            // Save to database
+            app.DB.Create(&models.Document{Title: df.Title, Content: df.Content})
+        } else {
+            // TEMP: kill the application if there is an form-parsing error
+            log.Fatal(err)
+        }
     }
 
     return c.Render()

--- a/app/controllers/document.go
+++ b/app/controllers/document.go
@@ -1,15 +1,27 @@
 package controllers
 
-import "github.com/revel/revel"
+import (
+    "github.com/revel/revel"
+    "github.com/GDG-SSU/wigo/app"
+    "github.com/GDG-SSU/wigo/app/models"
+)
 
 type Document struct {
     *revel.Controller
 }
 
 func (c Document) Write() revel.Result {
-    var title string
-    var content string
-    c.Params.Bind(&title, "title")
-    c.Params.Bind(&content, "content")
+
+    // When the submit button is clicked
+    if c.Request.Method == "POST" {
+        var title string
+        var content string
+        c.Params.Bind(&title, "title")
+        c.Params.Bind(&content, "content")
+
+        // Save to database
+        app.DB.Create(&models.Document{Title: title, Content: content})
+    }
+
     return c.Render()
 }

--- a/app/controllers/document.go
+++ b/app/controllers/document.go
@@ -1,0 +1,11 @@
+package controllers
+
+import "github.com/revel/revel"
+
+type Document struct {
+    *revel.Controller
+}
+
+func (c Document) Write() revel.Result {
+    return c.Render()
+}

--- a/app/controllers/document.go
+++ b/app/controllers/document.go
@@ -7,5 +7,9 @@ type Document struct {
 }
 
 func (c Document) Write() revel.Result {
+    var title string
+    var content string
+    c.Params.Bind(&title, "title")
+    c.Params.Bind(&content, "content")
     return c.Render()
 }

--- a/app/init.go
+++ b/app/init.go
@@ -3,9 +3,9 @@ package app
 import (
     "fmt"
 
-    "github.com/GDG-SSU/wigo/app/models"
     _ "github.com/go-sql-driver/mysql"
     "github.com/jinzhu/gorm"
+    "github.com/GDG-SSU/wigo/app/models"
     "github.com/revel/revel"
 )
 

--- a/app/views/Document/write.html
+++ b/app/views/Document/write.html
@@ -2,7 +2,12 @@
 {{template "header.html" .}}
 
 <div class="container">
-    <h1>Write Document</h1>
+    <h3>Write Document</h3>
+    <form action="/document/write" method="POST">
+        <input type="text" name="title" autofocus="true" placeholder="Title">
+        <textarea name="content"></textarea>
+        <button type="submit">Submit</button>
+    </form>
 </div>
 
 {{template "footer.html" .}}

--- a/app/views/Document/write.html
+++ b/app/views/Document/write.html
@@ -1,0 +1,8 @@
+{{set . "title" "Write Document"}}
+{{template "header.html" .}}
+
+<div class="container">
+    <h1>Write Document</h1>
+</div>
+
+{{template "footer.html" .}}


### PR DESCRIPTION
사용자는 `document/write`로 이동해서 새로운 위키 문서를 작성할 수 있습니다.

`document/write`에서 정해진 입력 폼 (문서 제목, 문서 내용) 에 따라서 문서를 작성하고 `Submit` 버튼을 클릭하면 문서가 데이터베이스 `documents` 테이블에 저장됩니다. 아직 위키 전반적인 스타일을 정하지 않았기에 CSS 없이 필요한 HTML 요소만 추가하였습니다.

기본적인 입력값 검증으로 문서 제목과 내용이 존재하는지 여부를 검사합니다. 임시적으로 문서 제목과 내용이 존재하지 않는 경우 애플리케이션이 종료되도록 로직이 구현되어 있습니다. 이 부분에 대해서는 오류 출력에 대한 논의를 거친 후에 기능을 추가하면 될 것 같습니다.

<img width="391" alt="2016-10-27 4 25 00" src="https://cloud.githubusercontent.com/assets/206832/19758192/f33fd750-9c61-11e6-87f3-eedcfa09b982.png">

관련 이슈: #2 
